### PR TITLE
Fixed spelling errors and omitted word in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Fully featured AWS Infinidash client for Rust applications. You can use the AWS 
 to get your application to scale on the AWS infrastructure automagically. AWS Infinidash leverages the blockchain to provide the
 ultimate security and scalability. The decentrality of the blockchain ensures that no single point of failure can be used to
 access the application. Using the Infinidash client, you can scale your application to any available AWS region, and you can
-scale your application to any available AWS account. Using assimetric cryptography, the Infinidash client can be used to
+scale your application to any available AWS account. Using asymmetric cryptography, the Infinidash client can be used to
 encrypt data between any two AWS regions with no need for any shared secret.
 
-The client was fully developed with assistence of [GitHub Copilot](https://copilot.github.com/) and is currently in beta. Production usage
-is recommended for now, but the client is still in development. If you find any bugs, please report them on the
+The client was fully developed with assistance of [GitHub Copilot](https://copilot.github.com/) and is currently in beta. Production usage
+is not recommended for now, but the client is still in development. If you find any bugs, please report them on the
 [issue tracker](https://github.com/rafaelcaricio/aws-infinidash-rs/issues).
 
 # Usage


### PR DESCRIPTION
The two spelling errors seem clear-cut. The word omission I'm pretty sure of as well as it was encouraging production usage as it was written.